### PR TITLE
support Gradle 7.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/snipking/cordova-hot-code-push.git"
+    "url": "git+https://github.com/christophersansone/cordova-hot-code-push.git"
   },
   "keywords": [
     "cordova",
@@ -40,7 +40,7 @@
   "author": "Nikolay Demyankov for Nordnet Bank AB",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/snipking/cordova-hot-code-push/issues"
+    "url": "https://github.com/christophersansone/cordova-hot-code-push/issues"
   },
-  "homepage": "https://github.com/snipking/cordova-hot-code-push#readme"
+  "homepage": "https://github.com/christophersansone/cordova-hot-code-push#readme"
 }

--- a/src/android/chcp.gradle
+++ b/src/android/chcp.gradle
@@ -9,8 +9,8 @@ cdvPluginPostBuildExtras.add({
     }
 
     dependencies {
-        compile 'com.fasterxml.jackson.core:jackson-core:2.4.4'
-        compile 'com.fasterxml.jackson.core:jackson-databind:2.4.4'
-        compile 'org.greenrobot:eventbus:3.0.0'
+        implementation 'com.fasterxml.jackson.core:jackson-core:2.4.4'
+        implementation 'com.fasterxml.jackson.core:jackson-databind:2.4.4'
+        implementation 'org.greenrobot:eventbus:3.0.0'
     }
 });


### PR DESCRIPTION
Fixes #14 .

The `compile` declaration was deprecated in previous versions of Gradle and has been removed in v7.0.  [Reference](https://github.com/gradle/gradle/issues/15661)

(Thanks for resurrecting this plugin!  It's always surprised me how this plugin was never more widely adopted.)